### PR TITLE
feat(moshi): moshi-hook のセットアップを dotfiles で同期する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Claude Code が生成するローカル作業用ファイル
+.claude/worktrees/
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -2,3 +2,23 @@
 
 ./dotfilesLink.sh
 
+# moshi
+
+[moshi](https://getmoshi.app) をセットアップする（Linux / WSL）。
+
+```sh
+./install/moshi.sh
+```
+
+moshi-hook の導入・ペアリング・Claude Code への hook 設定・デーモン常駐までを行う。何度実行してもよい。
+
+ペアリングトークン（アプリの Settings -> Integrations で発行）は public リポジトリに置かないため、
+以下から読む。どちらも無ければ実行時に対話入力し、`$HOME/.config/moshi/token` へ保存する。
+
+1. 環境変数 `MOSHI_PAIRING_TOKEN`
+2. `$HOME/.config/moshi/token`（`chmod 600`）
+
+- Claude Code の hook は `~/.claude/settings.json` に追記される（既存の hook 設定は保持される）
+- デーモンは systemd ユーザーサービス `moshi-hook.service` として常駐する
+- moshi-hook が扱わないジョブ（ビルド・デプロイ・cron など）からの通知は `moshi-notify "タイトル" "本文"`
+

--- a/command/moshi-notify
+++ b/command/moshi-notify
@@ -48,13 +48,21 @@ if [ -z "$token" ]; then
   exit 1
 fi
 
-# タイトル・本文に引用符や改行が含まれても壊れないよう jq で組み立てる
-payload=$(jq -nc \
-  --arg token "$token" \
-  --arg title "$title" \
-  --arg message "$message" \
-  --argjson unified "$unified" \
-  '{token: $token, title: $title, message: $message, unified: $unified}')
+# タイトル・本文に引用符や改行が含まれても壊れないよう jq で組み立てる。
+# unified は指定時のみ送る（既定のペイロードを公式ドキュメントの形と同一に保つため）
+if [ "$unified" = true ]; then
+  payload=$(jq -nc \
+    --arg token "$token" \
+    --arg title "$title" \
+    --arg message "$message" \
+    '{token: $token, title: $title, message: $message, unified: true}')
+else
+  payload=$(jq -nc \
+    --arg token "$token" \
+    --arg title "$title" \
+    --arg message "$message" \
+    '{token: $token, title: $title, message: $message}')
+fi
 
 response=$(printf '%s' "$payload" | curl -fsS -w '\n%{http_code}' \
   -X POST "$ENDPOINT" \

--- a/command/moshi-notify
+++ b/command/moshi-notify
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# moshi (https://getmoshi.app) へプッシュ通知を送る。
+# moshi-hook が面倒を見ないジョブ（長いビルド、デプロイ、cron など）から叩く用途。
+#
+#   moshi-notify "ビルド完了"
+#   moshi-notify "デプロイ完了" "本番へ反映しました"
+#   moshi-notify -u "全端末へ通知" "同一ライセンスの全デバイスに送る"
+#   make build && moshi-notify "build ok" || moshi-notify "build failed"
+#
+# トークンは install/moshi.sh と同じ場所から読む（リポジトリには置かない）:
+#   1. 環境変数 MOSHI_PAIRING_TOKEN
+#   2. $HOME/.config/moshi/token
+
+set -eu
+
+TOKEN_FILE="${MOSHI_TOKEN_FILE:-$HOME/.config/moshi/token}"
+ENDPOINT="${MOSHI_WEBHOOK_URL:-https://api.getmoshi.app/api/webhook}"
+
+usage() {
+  echo "usage: moshi-notify [-u] <title> [message]" >&2
+  echo "  -u  同一ライセンスの全デバイスへ通知する" >&2
+  exit 2
+}
+
+unified=false
+while getopts ':uh' opt; do
+  case "$opt" in
+    u) unified=true ;;
+    h) usage ;;
+    *) usage ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+title="${1:-}"
+message="${2:-}"
+[ -n "$title" ] || usage
+
+command -v jq > /dev/null 2>&1 || { echo "moshi-notify: jqが必要です" >&2; exit 1; }
+
+token="${MOSHI_PAIRING_TOKEN:-}"
+if [ -z "$token" ] && [ -r "$TOKEN_FILE" ]; then
+  token=$(tr -d '[:space:]' < "$TOKEN_FILE")
+fi
+if [ -z "$token" ]; then
+  echo "moshi-notify: トークンがありません（MOSHI_PAIRING_TOKEN または $TOKEN_FILE）" >&2
+  exit 1
+fi
+
+# タイトル・本文に引用符や改行が含まれても壊れないよう jq で組み立てる
+payload=$(jq -nc \
+  --arg token "$token" \
+  --arg title "$title" \
+  --arg message "$message" \
+  --argjson unified "$unified" \
+  '{token: $token, title: $title, message: $message, unified: $unified}')
+
+response=$(printf '%s' "$payload" | curl -fsS -w '\n%{http_code}' \
+  -X POST "$ENDPOINT" \
+  -H 'Content-Type: application/json' \
+  --data-binary @- 2>&1) || {
+  echo "moshi-notify: 送信に失敗しました: $response" >&2
+  exit 1
+}
+
+status="${response##*$'\n'}"
+if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+  echo "moshi-notify: 送信に失敗しました (HTTP $status): ${response%$'\n'*}" >&2
+  exit 1
+fi

--- a/install/moshi.sh
+++ b/install/moshi.sh
@@ -1,0 +1,162 @@
+#!/bin/sh
+
+# moshi (https://getmoshi.app) のセットアップ
+#
+# moshi-hook の導入 → ペアリング → Claude Code への hook 設定 → デーモン常駐 までを行う。
+# 何度実行しても安全（各ステップは設定済みならスキップする）。
+#
+# ペアリングトークンはこのリポジトリ（public）には絶対に置かない。以下の優先順で解決する:
+#   1. 環境変数 MOSHI_PAIRING_TOKEN
+#   2. $HOME/.config/moshi/token (chmod 600)
+#   3. 対話入力（入力値は 2 に保存する）
+# トークンは Moshi アプリの Settings -> Integrations で発行する。
+#
+# 対象は Linux / WSL。macOS は brew と Keychain を使うため対象外。
+
+set -u
+
+MOSHI_TOKEN_FILE="${MOSHI_TOKEN_FILE:-$HOME/.config/moshi/token}"
+
+# moshi-hook のインストール先。curl 版インストーラの既定値に合わせる
+export PATH="$HOME/.local/bin:$PATH"
+
+case "$(uname -s)" in
+  Linux) ;;
+  *)
+    echo "moshi.shはLinux/WSL専用です（macOSは brew install rjyo/moshi/moshi-hook を使ってください）"
+    exit 1
+    ;;
+esac
+
+# ペアリングトークンを解決して標準出力へ返す
+resolve_token() {
+  if [ -n "${MOSHI_PAIRING_TOKEN:-}" ]; then
+    printf '%s' "$MOSHI_PAIRING_TOKEN" | tr -d '[:space:]'
+    return 0
+  fi
+
+  if [ -r "$MOSHI_TOKEN_FILE" ]; then
+    tr -d '[:space:]' < "$MOSHI_TOKEN_FILE"
+    return 0
+  fi
+
+  # 対話端末が無ければ入力を求められないので失敗させる
+  if [ ! -t 0 ]; then
+    return 1
+  fi
+
+  printf 'Moshiのペアリングトークン（アプリの Settings -> Integrations）: ' > /dev/tty
+  read -r _token < /dev/tty
+  _token=$(printf '%s' "$_token" | tr -d '[:space:]')
+  [ -n "$_token" ] || return 1
+
+  # トークンはリポジトリ外（$HOME 配下）にのみ保存する
+  mkdir -p "$(dirname "$MOSHI_TOKEN_FILE")"
+  chmod 700 "$(dirname "$MOSHI_TOKEN_FILE")"
+  printf '%s\n' "$_token" > "$MOSHI_TOKEN_FILE"
+  chmod 600 "$MOSHI_TOKEN_FILE"
+  echo "トークンを $MOSHI_TOKEN_FILE に保存しました" > /dev/tty
+
+  printf '%s' "$_token"
+}
+
+# install moshi-hook
+moshi-hook version > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+  echo "moshi-hookをインストールします"
+  curl -fsSL https://getmoshi.app/install.sh | sh
+
+  # インストール後のバージョン確認
+  moshi-hook version > /dev/null 2>&1
+  if [ $? -ne 0 ]; then
+    echo "moshi-hookのインストールに失敗しました"
+    exit 1
+  fi
+else
+  echo "moshi-hookはインストール済みです"
+fi
+
+# pair moshi-hook
+moshi-hook status 2>/dev/null | grep -qE '^status: +paired'
+if [ $? -ne 0 ]; then
+  echo "moshi-hookをペアリングします"
+
+  token=$(resolve_token)
+  if [ -z "${token:-}" ]; then
+    echo "ペアリングトークンが取得できませんでした"
+    echo "  MOSHI_PAIRING_TOKEN を設定するか $MOSHI_TOKEN_FILE を作成してください"
+    exit 1
+  fi
+  if [ ${#token} -lt 16 ]; then
+    echo "ペアリングトークンが短すぎます（${#token}文字）。値を確認してください"
+    exit 1
+  fi
+
+  # WSL/headless では Keychain が使えないため file ストアを指定する
+  # サーバ側の一時エラーで失敗することがあるので一度だけリトライする
+  moshi-hook pair --token "$token" --store file
+  if [ $? -ne 0 ]; then
+    echo "ペアリングに失敗しました。再試行します"
+    sleep 3
+    moshi-hook pair --token "$token" --store file
+    if [ $? -ne 0 ]; then
+      echo "moshi-hookのペアリングに失敗しました"
+      exit 1
+    fi
+  fi
+  unset token
+else
+  echo "moshi-hookはペアリング済みです"
+fi
+
+# install claude code hooks
+moshi-hook status 2>/dev/null | grep -qE '^ +claude +current'
+if [ $? -ne 0 ]; then
+  echo "Claude Codeのhookを設定します"
+
+  # install は ~/.claude/settings.json を書き換えるので事前に控えを取る
+  CLAUDE_SETTINGS="$HOME/.claude/settings.json"
+  if [ -f "$CLAUDE_SETTINGS" ]; then
+    backup="$CLAUDE_SETTINGS.bak.$(date +%Y%m%d%H%M%S)"
+    cp "$CLAUDE_SETTINGS" "$backup"
+    echo "  $backup にバックアップしました"
+  fi
+
+  moshi-hook install --target claude
+  if [ $? -ne 0 ]; then
+    echo "Claude Codeのhook設定に失敗しました"
+    exit 1
+  fi
+else
+  echo "Claude Codeのhookは設定済みです"
+fi
+
+# run moshi-hook daemon
+moshi-hook probe 2>/dev/null | grep -qE '^running: +true'
+if [ $? -ne 0 ]; then
+  echo "moshi-hookデーモンをsystemdユーザーサービスとして常駐させます"
+  moshi-hook service install
+  if [ $? -ne 0 ]; then
+    echo "moshi-hookデーモンの常駐化に失敗しました"
+    echo "  systemdが無い環境では 'moshi-hook serve' を手動で起動してください"
+    exit 1
+  fi
+else
+  echo "moshi-hookデーモンは稼働中です"
+fi
+
+# enable linger
+# ユーザーのログアウト後もサービスを維持するために必要
+loginctl show-user "$(id -un)" --property=Linger 2>/dev/null | grep -q 'Linger=yes'
+if [ $? -ne 0 ]; then
+  echo "lingerを有効化します（ログアウト後もデーモンを維持するため）"
+  sudo loginctl enable-linger "$(id -un)"
+else
+  echo "lingerは有効です"
+fi
+
+echo ""
+echo "moshiのセットアップが完了しました"
+echo "  状態確認: moshi-hook status"
+echo "  ログ:     moshi-hook logs -f"
+echo "  通知送信: moshi-notify \"タイトル\" \"本文\""


### PR DESCRIPTION
## 概要

[moshi](https://getmoshi.app) のセットアップを dotfiles に取り込み、新しいマシンで再現できるようにする。

- `install/moshi.sh` — moshi-hook の導入 → ペアリング → Claude Code への hook 設定 → systemd ユーザーサービスでの常駐。各ステップは設定済みならスキップするので何度実行しても安全
- `command/moshi-notify` — moshi-hook が扱わないジョブ（ビルド・デプロイ・cron など）から webhook で通知を送る
- `.gitignore`（新規） — `EnterWorktree` が作る `.claude/worktrees/` を無視する。これまで `.gitignore` は存在せず `.gitiginore`（typo）だけがあった
- `README.md` — セットアップ手順を追記

## トークンの扱い

このリポジトリは public のため、ペアリングトークンは一切含めない。以下の優先順で解決する。

1. 環境変数 `MOSHI_PAIRING_TOKEN`
2. `$HOME/.config/moshi/token`（`chmod 600`）
3. 対話入力（入力値は 2 に保存）

## 検証済み

- `moshi-notify` の実送信 → 端末への通知到達を確認
- `PreToolUse[AskUserQuestion]` の hook 発火 → 端末への通知到達を確認
- `moshi-hook install` が `~/.claude/settings.json` の既存 hook 7 件を保持することを diff で確認
- 全ステップ設定済みの状態で `install/moshi.sh` を再実行し、冪等性を確認
- `moshi-notify` のペイロード生成（引用符・改行のエスケープ、`-u` フラグ、トークン欠如時のエラー、usage）

## 補足

- `moshi-hook logs` に hook イベントは記録されない（ログ粒度が INFO 未満）。動作していないわけではない
- `moshi-hook` の CLI は `XDG_RUNTIME_DIR` が無いと `/tmp/moshi-hook.sock` を見に行くため、systemd ログインセッション外（cron など）からはデーモンに到達できない。`install/moshi.sh` のヘルスチェックは gateway 経由で解決する `probe` を使っているため影響を受けない

🤖 Generated with [Claude Code](https://claude.com/claude-code)